### PR TITLE
Allow matrix input to proximal functions

### DIFF
--- a/prox_Sl1.m
+++ b/prox_Sl1.m
@@ -21,7 +21,7 @@ function op = prox_Sl1( lambda )
 
 if nargin == 0,
 	lambda = 1;
-elseif ~isnumeric( lambda ) || ~isreal( lambda ) ||  any( lambda <= 0, 'all' ) 
+elseif ~isnumeric( lambda ) || ~isreal( lambda ) ||  any( lambda(:) <= 0 ) 
 	error( 'Argument lambda must have all positive entries.' );
 end
 if ~issorted(flipud(lambda(:)))

--- a/prox_Sl1.m
+++ b/prox_Sl1.m
@@ -21,7 +21,7 @@ function op = prox_Sl1( lambda )
 
 if nargin == 0,
 	lambda = 1;
-elseif ~isnumeric( lambda ) || ~isreal( lambda ) ||  any( lambda <= 0 ) 
+elseif ~isnumeric( lambda ) || ~isreal( lambda ) ||  any( lambda <= 0, 'all' ) 
 	error( 'Argument lambda must have all positive entries.' );
 end
 if ~issorted(flipud(lambda(:)))

--- a/prox_l1.m
+++ b/prox_l1.m
@@ -12,7 +12,7 @@ function op = prox_l1( q )
 
 if nargin == 0,
 	q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') %|| numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q(:) < 0 ) || all(q(:)==0) %|| numel( q ) ~= 1
     if q==0
         op = prox_0;
         warning('TFOCS:zeroQ','q=0 so returning the proximal operator for the zero function');

--- a/prox_l1.m
+++ b/prox_l1.m
@@ -12,7 +12,7 @@ function op = prox_l1( q )
 
 if nargin == 0,
 	q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0 ) || all(q==0) %|| numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') %|| numel( q ) ~= 1
     if q==0
         op = prox_0;
         warning('TFOCS:zeroQ','q=0 so returning the proximal operator for the zero function');

--- a/prox_l1_and_sum.m
+++ b/prox_l1_and_sum.m
@@ -40,7 +40,7 @@ function op = prox_l1_and_sum( q, b, nColumns, zeroID, useMex )
 
 if nargin == 0
     q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') || numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q(:) < 0) || all(q(:)==0) || numel( q ) ~= 1
     error( 'Argument must be positive.' );
 end
 if nargin < 2 || isempty(b), b = 1; else, assert( numel(b) == 1 ); end

--- a/prox_l1_and_sum.m
+++ b/prox_l1_and_sum.m
@@ -40,7 +40,7 @@ function op = prox_l1_and_sum( q, b, nColumns, zeroID, useMex )
 
 if nargin == 0
     q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0 ) || all(q==0) || numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') || numel( q ) ~= 1
     error( 'Argument must be positive.' );
 end
 if nargin < 2 || isempty(b), b = 1; else, assert( numel(b) == 1 ); end

--- a/prox_l1_deadzone.m
+++ b/prox_l1_deadzone.m
@@ -12,7 +12,7 @@ function op = prox_l1_deadzone( q, epsilon )
 
 if nargin == 0,
 	q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0 ) || all(q==0) %|| numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') %|| numel( q ) ~= 1
     if q==0
         op = prox_0;
         warning('TFOCS:zeroQ','q=0 so returning the proximal operator for the zero function');

--- a/prox_l1_deadzone.m
+++ b/prox_l1_deadzone.m
@@ -12,7 +12,7 @@ function op = prox_l1_deadzone( q, epsilon )
 
 if nargin == 0,
 	q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') %|| numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q(:) < 0 ) || all(q(:)==0) %|| numel( q ) ~= 1
     if q==0
         op = prox_0;
         warning('TFOCS:zeroQ','q=0 so returning the proximal operator for the zero function');

--- a/prox_l1pos.m
+++ b/prox_l1pos.m
@@ -9,7 +9,7 @@ function op = prox_l1pos( q )
 
 if nargin == 0,
 	q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') %|| numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q(:) < 0 ) || all(q(:)==0) %|| numel( q ) ~= 1
 	error( 'Argument must be positive.' );
 end
 

--- a/prox_l1pos.m
+++ b/prox_l1pos.m
@@ -9,7 +9,7 @@ function op = prox_l1pos( q )
 
 if nargin == 0,
 	q = 1;
-elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0 ) || all(q==0) %|| numel( q ) ~= 1
+elseif ~isnumeric( q ) || ~isreal( q ) ||  any( q < 0, 'all' ) || all(q==0, 'all') %|| numel( q ) ~= 1
 	error( 'Argument must be positive.' );
 end
 

--- a/prox_l2.m
+++ b/prox_l2.m
@@ -31,7 +31,7 @@ if isscalar(q)
     end
     op = @(varargin)prox_l2_q( q, varargin{:} );
 else
-    if all(q==0), error('Argument must be nonzero'); end
+    if all(q==0, 'all'), error('Argument must be nonzero'); end
     warning('TFOCS:experimental','Using experimental feature of TFOCS');
     op = @(varargin)prox_l2_vector( q, varargin{:} );
 end

--- a/prox_l2.m
+++ b/prox_l2.m
@@ -31,7 +31,7 @@ if isscalar(q)
     end
     op = @(varargin)prox_l2_q( q, varargin{:} );
 else
-    if all(q==0, 'all'), error('Argument must be nonzero'); end
+    if all(q(:)==0), error('Argument must be nonzero'); end
     warning('TFOCS:experimental','Using experimental feature of TFOCS');
     op = @(varargin)prox_l2_vector( q, varargin{:} );
 end


### PR DESCRIPTION
Allow matrix input to the following proximal functions:
prox_Sl1.m
prox_l1.m
prox_l1_and_sum.m
prox_l1_deadzone.m
prox_l1pos.m
prox_l2.m